### PR TITLE
feat: add versioning option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ as described in the `.pre-commit-config.yaml` file
 | [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_s3_object.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
@@ -111,6 +112,7 @@ as described in the `.pre-commit-config.yaml` file
 | <a name="input_route53_domain"></a> [route53\_domain](#input\_route53\_domain) | Route53 hosted zone domain where the DNS record should be created. This is used for TLS certificate validation too. If 'null' then skip it. | `string` | `null` | no |
 | <a name="input_static_content_path"></a> [static\_content\_path](#input\_static\_content\_path) | Path to the website static files to be uploaded to S3. If 'null', no objects are uploaded and app deployment can be handled separately. | `string` | `null` | no |
 | <a name="input_url"></a> [url](#input\_url) | URL where the application is going to be served on. CloudFront will be deployed and a DNS record pointing to it too | `string` | n/a | yes |
+| <a name="input_versioning"></a> [versioning](#input\_versioning) | Bucket versioning. Either "", "Enabled", "Suspended" of "Disabled" | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/minimal.tf
+++ b/examples/minimal.tf
@@ -28,6 +28,7 @@ module "frontend_complete" {
 
   # Optional
   static_content_path = "./build/"
+  versioning          = "Enabled"
 
   providers = {
     aws.us = aws.us

--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,16 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
   }
 }
 
+resource "aws_s3_bucket_versioning" "this" {
+  count = var.versioning != "" ? 1 : 0
+
+  bucket = aws_s3_bucket.this.id
+
+  versioning_configuration {
+    status = var.versioning
+  }
+}
+
 module "source_code" {
   count = var.static_content_path != null ? 1 : 0
 

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "bucket_name" {
   default     = null
 }
 
+variable "versioning" {
+  description = "Bucket versioning. Either \"\", \"Enabled\", \"Suspended\" of \"Disabled\""
+  type        = string
+  default     = ""
+}
+
 variable "index_page" {
   description = "Index page that should be displayed as root. Defauls to `index.html`"
   type        = string


### PR DESCRIPTION
To add the versioning option.

- Tested by creating new static-website with all versioning possibilities --> OK
- Tested by updating a deployed static-website from v0.2.0 to fum-versioning without change in terraform --> OK
- Tested by adding the versioning=Enabled on the deployed static-websit --> OK

After merge, it will be v0.3.0 (new feature but no breaking change)