### PR TITLE
fix: use bool instead of string for versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ as described in the `.pre-commit-config.yaml` file
 | <a name="input_cloudfront_additional_cnames"></a> [cloudfront\_additional\_cnames](#input\_cloudfront\_additional\_cnames) | List of Altername names to use for the CloudFront distribution | `list(string)` | `[]` | no |
 | <a name="input_cloudfront_cache_default_ttl"></a> [cloudfront\_cache\_default\_ttl](#input\_cloudfront\_cache\_default\_ttl) | Default TTL (in seconds) for objects stored in S3 that will be served through CloudFront. | `number` | `30` | no |
 | <a name="input_cloudfront_redirected_http_codes"></a> [cloudfront\_redirected\_http\_codes](#input\_cloudfront\_redirected\_http\_codes) | List of HTTP status codes that are meant to be redirected to the var.index\_page | `list(string)` | <pre>[<br>  403,<br>  404<br>]</pre> | no |
+| <a name="input_enable_bucket_versioning"></a> [enable\_bucket\_versioning](#input\_enable\_bucket\_versioning) | If bucket versioning should be enabled. By default, bucket will have versioning disabled. A boolean value will tell if it's 'Enabled' or 'Suspended' | `bool` | `null` | no |
 | <a name="input_error_page"></a> [error\_page](#input\_error\_page) | Error page that should be displayed whenever CloudFront returns any of the 'var.cloudfront\_redirected\_http\_codes'. Defauls to `index.html` | `string` | `"index.html"` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Set this to true, apply and then you are able to force destroy all the resources in the cluster. | `bool` | `false` | no |
 | <a name="input_index_page"></a> [index\_page](#input\_index\_page) | Index page that should be displayed as root. Defauls to `index.html` | `string` | `"index.html"` | no |
 | <a name="input_route53_domain"></a> [route53\_domain](#input\_route53\_domain) | Route53 hosted zone domain where the DNS record should be created. This is used for TLS certificate validation too. If 'null' then skip it. | `string` | `null` | no |
 | <a name="input_static_content_path"></a> [static\_content\_path](#input\_static\_content\_path) | Path to the website static files to be uploaded to S3. If 'null', no objects are uploaded and app deployment can be handled separately. | `string` | `null` | no |
 | <a name="input_url"></a> [url](#input\_url) | URL where the application is going to be served on. CloudFront will be deployed and a DNS record pointing to it too | `string` | n/a | yes |
-| <a name="input_versioning"></a> [versioning](#input\_versioning) | Bucket versioning. Either "", "Enabled", "Suspended" of "Disabled" | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/minimal.tf
+++ b/examples/minimal.tf
@@ -27,8 +27,8 @@ module "frontend_complete" {
   cloudfront_additional_cnames = ["autolayout-2.ness-dev.tamedia.ch"]
 
   # Optional
-  static_content_path = "./build/"
-  versioning          = "Enabled"
+  static_content_path      = "./build/"
+  enable_bucket_versioning = true
 
   providers = {
     aws.us = aws.us

--- a/main.tf
+++ b/main.tf
@@ -44,12 +44,12 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
 }
 
 resource "aws_s3_bucket_versioning" "this" {
-  count = var.versioning != "" ? 1 : 0
+  count = var.enable_bucket_versioning == null ? 0 : 1
 
   bucket = aws_s3_bucket.this.id
 
   versioning_configuration {
-    status = var.versioning
+    status = var.enable_bucket_versioning ? "Enabled" : "Suspended"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -15,10 +15,10 @@ variable "bucket_name" {
   default     = null
 }
 
-variable "versioning" {
-  description = "Bucket versioning. Either \"\", \"Enabled\", \"Suspended\" of \"Disabled\""
-  type        = string
-  default     = ""
+variable "enable_bucket_versioning" {
+  description = "If bucket versioning should be enabled. By default, bucket will have versioning disabled. A boolean value will tell if it's 'Enabled' or 'Suspended'"
+  type        = bool
+  default     = null
 }
 
 variable "index_page" {


### PR DESCRIPTION
Use a boolean instead of a string for the versioning.

- Creation of a static-website with enable_bucket_version = null --> successful, s3 bucket versioning is "Disabled"
- Creation of a static-website with enable_bucket_version = false --> successful, s3 bucket versioning is "Suspended"
- Creation of a static-website with enable_bucket_version = true --> successful, s3 bucket versioning is "Enabled"
- Switching from false to true --> successful, s3 bucket versioning switched from "Suspended" to "Enabled"
- Switching from true to false --> successful, s3 bucket versioning switched from "Enabled" to "Suspended"
- Switching from null to true --> successful, s3 bucket versioning switched from "Disabled" to "Enabled"
- Switching from null to false --> successful, s3 bucket versioning switched from "Disabled" to "Suspended"
- Switching from false to null --> successful, aws_s3_bucket_versioning resource deleted, no impact/change on s3 bucket versioning (stay in "Suspended")
- Switching from true to null --> successful, aws_s3_bucket_versioning resource deleted, s3 bucket versioning switched from "Enabled" to "Suspended"
- Switching back from null to true --> successful, aws_s3_bucket_versioning resource recreated, s3 bucket versioning switched from "Suspended" to "Enabled"
- Switching back from null to false --> successful, aws_s3_bucket_versioning resource recreated, no impact/change on s3 bucket versioning (stay in "Suspended")

I will create v0.4.0